### PR TITLE
[FIX] res_currency_print_on_check: issue with the xpath.

### DIFF
--- a/res_currency_print_on_check/__openerp__.py
+++ b/res_currency_print_on_check/__openerp__.py
@@ -53,4 +53,5 @@ Contributors
     'demo': [],
     'test': [],
     'installable': True,
+    'active': False,
 }

--- a/res_currency_print_on_check/__openerp__.py
+++ b/res_currency_print_on_check/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': 'Display name for currencies',
-    'version': '1.0',
+    'version': '1.1',
     'author': 'Savoir-faire Linux',
     'website': 'http://www.savoirfairelinux.com',
     'category': 'Generic Modules/Accounting',

--- a/res_currency_print_on_check/currency.py
+++ b/res_currency_print_on_check/currency.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Odoo, Open Source Management Solution
-#    Copyright (C) 2010 - 2014 Savoir-faire Linux
-#    (<http://www.savoirfairelinux.com>).
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2013 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -22,9 +21,8 @@
 
 from openerp.osv import orm, fields
 
-
 class res_currency(orm.Model):
     _inherit = 'res.currency'
     _columns = {
-        'print_on_check': fields.char('Display Name', size=64, translate=True),
+        'print_on_check': fields.char('New Display Name', size=64, translate=True),
     }

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@string='rate_silent']" position="after">
+                <xpath expr="//field[@name='rate_silent']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Miscellaneous']" position="inside">
+                <xpath expr="//field[@string='rate_silent']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//form[@string='Currency']/group[1]/field[last()]" position="after">
+                <xpath expr="//group[string='Miscellaneous']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//form/group[1]/field[last()]" position="after">
+                <xpath expr="//form[@string='Currency']/group[1]/field[last()]" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[string='Miscellaneous']" position="after">
+                <xpath expr="//group[@string='Miscellaneous']" position="inside">
                     <field name="print_on_check"/>
                 </xpath>
             </field>


### PR DESCRIPTION
fix for https://github.com/OCA/l10n-canada/issues/8

When the xpath was first built only one form was in base.view_currency_form. Then the form for the search feartures had been added.  The second form made the xpath to return two fields. To avoid this behaviour, the form to be found in the xpath had been specified. It is less environment agnostic but base.view_currency_form form name seems to be stable.
