### PR TITLE
7.0 tweaks l10n ca account check writing

### DIFF
--- a/l10n_ca_account_check_writing/__openerp__.py
+++ b/l10n_ca_account_check_writing/__openerp__.py
@@ -21,7 +21,7 @@
 ##############################################################################
 {
     'name': 'Canada - Check Writing',
-    'version': '1.2',
+    'version': '1.3',
     'author': 'Savoir-faire Linux',
     'website': 'http://www.savoirfairelinux.com',
     'category': 'Generic Modules/Accounting',
@@ -49,7 +49,10 @@ Contributors
 * Maxime Chambreuil (maxime.chambreuil@savoirfairelinux.com)
 * Vincent Vinet (vincent.vinet@savoirfairelinux.com)
 * Virgil Dupras (virgil.dupras@savoirfairelinux.com)
-* Sandy Carter (sandyt.carter@savoirfairelinux.com)
+* Sandy Carter (sandy.carter@savoirfairelinux.com)
+* Jordi Riera (jordi.riera@savoirfairelinux.com)
+* William Berverly (william.beverly@savoirfairelinux.com)
+
     """,
     'depends': [
         'account_check_writing',

--- a/l10n_ca_account_check_writing/report/l10n_ca_check_print.py
+++ b/l10n_ca_account_check_writing/report/l10n_ca_check_print.py
@@ -19,7 +19,9 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
+import logging
+_logger = logging.getLogger(__name__)
+import re
 import time
 from openerp.tools import config
 from openerp.report import report_sxw
@@ -29,7 +31,6 @@ from openerp.tools.translate import _
 # This is why we use the library below. You can get it at:
 # https://pypi.python.org/pypi/num2words
 from num2words import num2words
-
 # For the words we use in custom_translation(), we have to put dummy _()
 # calls here so that Odoo picks them up during .pot generation
 _("and")
@@ -131,22 +132,34 @@ class report_print_check(report_sxw.rml_parse):
     def _get_amount_line(amount, currency, lang):
         # max char with font Courier 9.0
         max_char = 72
-        try:
-            amount_in_word = num2words(int(amount), lang=lang[:2])
-        except NotImplementedError:
-            amount_in_word = num2words(int(amount))
-        currency_name = currency.print_on_check
+        # turning the amount into integer removes all the decimals.
+        # We will use that to turn the base into word but we want to keep the
+        # cents into numbers.
+        base_amont = int(amount)
+        # Extraction of cents
         cents = int(amount * 100) % 100
-        AND = custom_translation("and", lang)
+        currency_name = currency.print_on_check
+
+        try:
+            base_amount_in_word = num2words(base_amont, lang=lang[:2])
+        except NotImplementedError:
+            base_amount_in_word = num2words(base_amont)
+
+        # it should not have any AND in the base_amount_in_word
+        # so we just use the power of regex to sub them.
+        base_amount_in_word = re.sub(r' and ', ' ', base_amount_in_word)
 
         if lang.startswith('fr'):
             first_line = u'{amount_in_word} {currency_name} {AND} {cents}/100 '
         else:
             first_line = u'{amount_in_word} {AND} {cents}/100 {currency_name} '
 
-        first_line = first_line.format(AND=AND, currency_name=currency_name,
-                                       amount_in_word=amount_in_word,
-                                       cents=cents)
+        first_line = first_line.format(
+            AND=custom_translation("and", lang),
+            currency_name=currency_name,
+            amount_in_word=base_amount_in_word,
+            cents=cents
+        )
 
         first_line = first_line.title()
 

--- a/l10n_ca_account_check_writing/report/l10n_ca_check_print_middle.rml
+++ b/l10n_ca_account_check_writing/report/l10n_ca_check_print_middle.rml
@@ -104,7 +104,7 @@
     <blockTable colWidths="568.0" style="Table2" rowHeights="280">
       <tr>
         <td>
-          <blockTable colWidths="485.0,67.0" style="Table6">
+          <blockTable colWidths="465.0,87.0" style="Table6">
             <tr>
               <td>
                 <para style="P16"></para>
@@ -122,7 +122,7 @@
               </td>
             </tr>
           </blockTable>
-          <blockTable colWidths="81.0,186.0,83.0,81.0,54.0,78.0" style="Table10">
+          <blockTable colWidths="81.0,176.0,83.0,81.0,64.0,78.0" style="Table10">
             <tr>
               <td>
                 <para style="P4">Date</para>
@@ -197,7 +197,7 @@
       </tr>
     </blockTable>
 
-    <blockTable colWidths="400.0,50.0" rowHeights="29.3" style="Table5">
+    <blockTable colWidths="380.0,70.0" rowHeights="29.3" style="Table5">
 	<tr>
 	    <td>
                 <para style="P25">Date</para>
@@ -222,7 +222,7 @@
     <blockTable colWidths="568.0"  style="Table1">
       <tr>
         <td>
-          <blockTable colWidths="30.0,420.0,50.0" rowHeights="22.8,130.0" style="Table12">
+          <blockTable colWidths="30.0,400.0,70.0" rowHeights="22.8,130.0" style="Table12">
             <tr>
               <td>
                   <para style="P3"><font color="white"> </font></para>
@@ -280,7 +280,7 @@
               </td>
             </tr>
           </blockTable>
-          <blockTable colWidths="82.0,185.0,89.0,76.0,52.0,78.0" style="Table8">
+          <blockTable colWidths="82.0,155.0,89.0,86.0,72.0,78.0" style="Table8">
             <tr>
               <td>
                 <para style="P4">Date</para>

--- a/l10n_ca_account_check_writing/tests/__init__.py
+++ b/l10n_ca_account_check_writing/tests/__init__.py
@@ -26,5 +26,3 @@ from . import (
 checks = [
     test_l10n_ca_check_print,
 ]
-
-

--- a/l10n_ca_account_check_writing/tests/__init__.py
+++ b/l10n_ca_account_check_writing/tests/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# #############################################################################
+#
+# Odoo, Open Source Management Solution
+#    Copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import (
+    test_l10n_ca_check_print
+)
+
+checks = [
+    test_l10n_ca_check_print,
+]
+
+

--- a/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
+++ b/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
@@ -1,0 +1,71 @@
+# -*- encoding: utf-8 -*-
+#
+# OpenERP, Open Source Management Solution
+# This module copyright (C) 2014 Savoir-faire Linux
+# (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from openerp.addons.l10n_ca_account_check_writing.report.l10n_ca_check_print import report_print_check  # noqa
+from openerp.tests import common
+
+
+class test_base_format(common.TransactionCase):
+    def setUp(self):
+        super(test_base_format, self).setUp()
+        self.ref = self.registry('ir.model.data')
+        self.report = report_print_check
+        self.cad = self.ref.get_object(self.cr, self.uid, 'base', 'CAD')
+        self.get_amount_line = self.report._get_amount_line
+
+
+    def test_get_amount_line_returns(self):
+        self.assertEqual(
+            self.get_amount_line(666, self.cad, 'en'),
+            ('***********************Six Hundred Sixty-Six '
+             'And 0/100 Canadian Dollars ')
+        )
+
+        self.assertEqual(
+            self.get_amount_line(666.00, self.cad, 'en'),
+            ('***********************Six Hundred Sixty-Six '
+             'And 0/100 Canadian Dollars ')
+        )
+
+        self.assertEqual(
+            self.get_amount_line(666.11, self.cad, 'en'),
+            ('**********************Six Hundred Sixty-Six '
+             'And 11/100 Canadian Dollars ')
+        )
+
+        # testing French also, as it is also an official language in Canada.
+        # We call the method directly, without running all the process of odoo,
+        # that why only num2word words are translated here.
+        self.assertEqual(
+            self.get_amount_line(666.11, self.cad, 'fr'),
+            ('**********************Six Cent Soixante-Six Canadian Dollars '
+             'And 11/100 ')
+        )
+
+
+    def test_get_amount_line_returns_72_chars(self):
+        """ To no break the check layout, the amount should always be 72
+        characters. Too small lines are filled with stars.
+        """
+        self.assertEqual(len(self.get_amount_line(666, self.cad, 'en')), 72)
+        self.assertEqual(len(self.get_amount_line(666.11, self.cad, 'en')), 72)
+        self.assertEqual(len(self.get_amount_line(666.11, self.cad, 'fr')), 72)
+

--- a/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
+++ b/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
@@ -23,9 +23,9 @@ from openerp.addons.l10n_ca_account_check_writing.report.l10n_ca_check_print imp
 from openerp.tests import common
 
 
-class test_base_format(common.TransactionCase):
+class test_l10n_ca_check_print(common.TransactionCase):
     def setUp(self):
-        super(test_base_format, self).setUp()
+        super(test_l10n_ca_check_print, self).setUp()
         self.ref = self.registry('ir.model.data')
         self.report = report_print_check
         self.cad = self.ref.get_object(self.cr, self.uid, 'base', 'CAD')

--- a/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
+++ b/l10n_ca_account_check_writing/tests/test_l10n_ca_check_print.py
@@ -31,7 +31,6 @@ class test_l10n_ca_check_print(common.TransactionCase):
         self.cad = self.ref.get_object(self.cr, self.uid, 'base', 'CAD')
         self.get_amount_line = self.report._get_amount_line
 
-
     def test_get_amount_line_returns(self):
         self.assertEqual(
             self.get_amount_line(666, self.cad, 'en'),
@@ -60,7 +59,6 @@ class test_l10n_ca_check_print(common.TransactionCase):
              'And 11/100 ')
         )
 
-
     def test_get_amount_line_returns_72_chars(self):
         """ To no break the check layout, the amount should always be 72
         characters. Too small lines are filled with stars.
@@ -68,4 +66,3 @@ class test_l10n_ca_check_print(common.TransactionCase):
         self.assertEqual(len(self.get_amount_line(666, self.cad, 'en')), 72)
         self.assertEqual(len(self.get_amount_line(666.11, self.cad, 'en')), 72)
         self.assertEqual(len(self.get_amount_line(666.11, self.cad, 'fr')), 72)
-

--- a/res_currency_print_on_check/__openerp__.py
+++ b/res_currency_print_on_check/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': 'Display name for currencies',
-    'version': '1.0',
+    'version': '1.1',
     'author': 'Savoir-faire Linux',
     'website': 'http://www.savoirfairelinux.com',
     'category': 'Generic Modules/Accounting',

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@string='rate_silent']" position="after">
+                <xpath expr="//field[@name='rate_silent']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[@string='Miscellaneous']" position="inside">
+                <xpath expr="//field[@string='rate_silent']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//form[@string='Currency']/group[1]/field[last()]" position="after">
+                <xpath expr="//group[string='Miscellaneous']" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//form/group[1]/field[last()]" position="after">
+                <xpath expr="//form[@string='Currency']/group[1]/field[last()]" position="after">
                     <field name="print_on_check"/>
                 </xpath>
             </field>

--- a/res_currency_print_on_check/currency_view.xml
+++ b/res_currency_print_on_check/currency_view.xml
@@ -7,7 +7,7 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//group[string='Miscellaneous']" position="after">
+                <xpath expr="//group[@string='Miscellaneous']" position="inside">
                     <field name="print_on_check"/>
                 </xpath>
             </field>


### PR DESCRIPTION
Several issues were found in the CA checks:
- some columns were to small to accept its own content
- the amount in word was not answering official canadian standard. It should not have "And"s between the numbers in the base amount. The only "And" accepted is between dollars et les cents.

Unittests were added to test the output of amount_in_line method
