### PR TITLE
[7.0] spacing fix in check RML

### DIFF
--- a/l10n_ca_account_check_writing/report/l10n_ca_check_print_top.rml
+++ b/l10n_ca_account_check_writing/report/l10n_ca_check_print_top.rml
@@ -293,23 +293,6 @@
                 </para>
               </td>
             </tr>
-            <tr>
-              <td>
-                <para style="P5">
-                  <font color="white"> </font>
-                </para>
-              </td>
-              <td>
-                <para style="P5">
-                  <font color="white"> </font>
-                </para>
-              </td>
-              <td>
-                <para style="P1">
-                  <font color="white"> </font>
-                </para>
-              </td>
-            </tr>
           </blockTable>
           <para style="P1">
             <font color="white"> </font>
@@ -409,7 +392,7 @@
               </td>
             </tr>
           </blockTable>
-          <blockTable colWidths="68.0,157.0,70.0,69.0,141.0,80.0" style="Table5">
+          <blockTable colWidths="84.0,193.0,86.0,85.0,56.0,80.0" style="Table5">
             <tr>
               <td>
                 <para style="P4">Date</para>
@@ -466,15 +449,9 @@
               </td>
             </tr>
           </blockTable>
-          <para style="P25">
-            <font color="white"> </font>
-          </para>
         </td>
       </tr>
     </blockTable>
-    <para style="P14">
-      <font color="white"> </font>
-    </para>
   </story>
 </document>
 


### PR DESCRIPTION
This is what's left of the merge_sfl_branch_from_lp branch.

It fixes column widths and remove spacer paragraphs to avoid having checks
overflow into a second page when they should not.
